### PR TITLE
Handle pagination via Splash

### DIFF
--- a/AutoRiaScraper/AutoRiaScraper/spiders/AutoRiaSpider.py
+++ b/AutoRiaScraper/AutoRiaScraper/spiders/AutoRiaSpider.py
@@ -5,6 +5,7 @@ from scrapy import Spider, Request
 from scrapy.http.response.html import HtmlResponse
 from scrapy.loader import ItemLoader
 from scrapy_splash import SplashRequest
+from scrapy.shell import inspect_response
 
 from AutoRiaScraper.items import SpiderArguments, CarItemsOnCategoryPage
 
@@ -22,7 +23,7 @@ class AutoriaSpider(Spider):
     """Spdier to parse information about cars, based on specified filters from the main page"""
     name = 'autoria_spider'
     allowed_domains = ['auto.ria.com']
-    start_urls = ['https://auto.ria.com/uk']
+    start_urls = ['https://auto.ria.com/uk/legkovie/?page=1']
 
     def __init__(self, *args, **kwargs):
         """"""
@@ -30,7 +31,7 @@ class AutoriaSpider(Spider):
         self.args = SpiderArguments(**kwargs)
 
     def start_requests(self):
-        """Performs either splash or default requests to the page with cars, according to the input spider arguments"""
+        """Performs either splash or default scrapy requests to the page with cars, according to the input spider arguments"""
         request_args = {
             "callback": self.parse,
         }
@@ -50,17 +51,34 @@ class AutoriaSpider(Spider):
 
     def parse(self, response: HtmlResponse) -> Iterator[Dict[str, str]]:
         """Iterates over car items and performs requests to each individual car page"""
+        # inspect_response(response, self)
         item = ItemLoader(item=CarItemsOnCategoryPage(), response=response)
         item.add_value("current_page_url", response.url)
         item.add_xpath("next_page_url", "//a[@class='page-link js-next ']/@href")
         item.add_xpath("car_urls_on_page", "//div[@class='item ticket-title']/a/@href")
         loaded_item = item.load_item()
 
-        for car_url in loaded_item.car_urls_on_page:
-            pass
+        try:
+            for car_url in loaded_item["car_urls_on_page"]:
+                print("GONNA VIIST CAR URL: ", car_url)
+        except KeyError:
+            self.logger.warning(f"Car items are missing in URL {loaded_item['current_page_url']}")
+            return
 
-        if loaded_item.next_page_url:
-            yield Request(loaded_item.next_page_url, callback=self.parse)
+        try:
+            next_page_request = SplashRequest(
+                callback=self.parse,
+                url=loaded_item["next_page_url"],
+                endpoint="execute",
+                args={
+                    "lua_source": lua_script,
+                },
+                cache_args=["lua_source"],
+            )
+        except KeyError:
+            self.logger.warning("No pagination in URL {loaded_item['current_page_url']}")
+            return
+        yield next_page_request
 
 
     def parse_car_page(self, response: HtmlResponse):


### PR DESCRIPTION
The new functionality provides the way to iterate over category pages via pagination and follow all available links with car ads to completely scrape information about each particular car.
Internaly, to loop through links in the pagination bar, it needs to perform splash requests, otherwise the content will not be available. Thus, stick to the strategy of using splash requests to follow all links on the web site.